### PR TITLE
Add zip package to list of required packages for Ubuntu install.

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -40,7 +40,7 @@ To build Bazel on Ubuntu:
 
 2. Install required packages:
 
-        $ sudo apt-get install libarchive-dev pkg-config
+        $ sudo apt-get install libarchive-dev pkg-config zip
 
 3. Build Bazel:
 


### PR DESCRIPTION
I hit a minor bump when trying to install.  For some reason I didn't have the 'zip' package for Ubuntu (not default installed I guess?), so I added it to the list of required packages.  I assume there are others that would be needed here (C++ toolchain?).