### PR TITLE
Update classfile.cc

### DIFF
--- a/third_party/ijar/classfile.cc
+++ b/third_party/ijar/classfile.cc
@@ -27,6 +27,7 @@
 // http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4
 
 #define __STDC_LIMIT_MACROS 1
+#define __STDC_FORMAT_MACROS 1
 #include <inttypes.h> // for PRIx32
 #include <stddef.h>
 #include <stdio.h>


### PR DESCRIPTION
PRIx32 macro needs __STDC_FORMAT_MACRO defined on systems instead of __STDC_LIMIT_MACROS