### PR TITLE
Fixed the broken build caused by missing includes.

### DIFF
--- a/src/main/native/localsocket.cc
+++ b/src/main/native/localsocket.cc
@@ -17,6 +17,7 @@
 #include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <unistd.h>
 #include <poll.h>
 #include <sys/types.h>

--- a/src/main/native/unix_jni.cc
+++ b/src/main/native/unix_jni.cc
@@ -17,6 +17,7 @@
 #include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <limits.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/resource.h>


### PR DESCRIPTION
Tested on OSX 10.8.5 with jdk8 and gcc-4.8 (installed by brew).