### PR TITLE
Fix compiling error when project path contains spaces.

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -118,9 +118,9 @@ EOF
 }
 
 # Create symlinks so we can use tools and examples from the base_workspace.
-rm -f base_workspace/tools && ln -s $(pwd)/tools base_workspace/tools
-rm -f base_workspace/third_party && ln -s $(pwd)/third_party base_workspace/third_party
-rm -f base_workspace/examples && ln -s $(pwd)/examples base_workspace/examples
+rm -f base_workspace/tools && ln -s "$(pwd)/tools" base_workspace/tools
+rm -f base_workspace/third_party && ln -s "$(pwd)/third_party" base_workspace/third_party
+rm -f base_workspace/examples && ln -s "$(pwd)/examples" base_workspace/examples
 
 case "${PLATFORM}" in
 linux)


### PR DESCRIPTION
When the project path contains spaces, compilation will generate `ln: base_workspace/tools: No such file or directory` error. This simple fix will resolve that problem.