### PR TITLE
Fix exporting path typo in the installation guide

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -104,7 +104,7 @@ The Bazel executable is located at `output/bazel` in the bazel directory.
 It's a good idea to add this path to your default paths, like so (you
 can also add this command to your `~/.bashrc`):
 
-    $ export PATH="$PATH:$HOME/bazel/output/bazel"
+    $ export PATH="$PATH:$HOME/bazel/output"
 
 You must run Bazel from within a source code tree that is properly
 configured for use with Bazel. We call such a tree a _workspace


### PR DESCRIPTION
`export PATH` should contain the directory containing the binaries rather than the binaries themselves.