### PR TITLE
py_binary correctly forwards arguments

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/python/stub_template.txt
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/python/stub_template.txt
@@ -2,4 +2,4 @@
 
 STUBPATH=$(python -c "import os.path; print os.path.realpath('$0');")
 export PYTHONPATH=$STUBPATH.runfiles
-python ${PYTHONPATH}/%main%
+python ${PYTHONPATH}/%main% $@


### PR DESCRIPTION
I noticed that Python binaries would not forward command line arguments when called using the shell script. 