### PR TITLE
Fix compile.sh for macports

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -99,7 +99,8 @@ EOF
 
       elif [[ -e $macports_header ]]; then
         # For use with Macports.
-        archive_dir=$(dirname $(dirname $macports_header)) rm -f fromhost/*.[ah]
+        archive_dir=$(dirname $(dirname $macports_header))
+        rm -f fromhost/*.[ah]
         touch fromhost/empty.c
         cp "${archive_dir}"/include/{archive.h,archive_entry.h} fromhost/
         cp "${archive_dir}"/lib/{libarchive,liblzo2,liblzma,libcharset,libbz2,libxml2,libz,libiconv}.a \


### PR DESCRIPTION
Fixes #142 by adding a newline to compile.sh so that the archive_dir variable is
preserved when building with macports.  

Without this, we see the following:
<pre>
$ ./compile.sh
cp: /include/archive.h: No such file or directory
cp: /include/archive_entry.h: No such file or directory
</pre>