### PR TITLE
Fix up momc command line to match xcode.

### DIFF
--- a/src/tools/xcode-common/java/com/google/devtools/build/xcode/zippingoutput/Wrappers.java
+++ b/src/tools/xcode-common/java/com/google/devtools/build/xcode/zippingoutput/Wrappers.java
@@ -97,6 +97,15 @@ public class Wrappers {
     if (printOutput) {
       processBuilder = processBuilder.inheritIO();
     }
+    // Useful for logging the actual command that is being zipped up.
+    // Should expose this in output when --verbose_failures are on or -s.
+    // https://github.com/google/bazel/issues/197
+    boolean logCommand = false;
+    if (logCommand) {
+      System.out.print(System.getenv().toString() + "\n");
+      System.out.print("(" + String.join(" ", processBuilder.command()) + ")\n");
+      System.out.flush();
+    }
     Process subProcess = processBuilder.start();
     int exit = subProcess.waitFor();
     OutErr outErr = new OutErr(


### PR DESCRIPTION
Bazel:
momc -XD_MOMC_SDKROOT={...}iPhoneSimulator8.3.sdk -MOMC_PLATFORMS iphonesimulator -XD_MOMC_IOS_TARGET_VERSION=7.0 foo.xcdatamodeld foo.momd

Xcode:
momc -XD_MOMC_SDKROOT={...}iPhoneSimulator8.3.sdk -XD_MOMC_IOS_TARGET_VERSION=7.0 -MOMC_PLATFORMS iphonesimulator foo.xcdatamodeld foo.momd

Also adds support for logging output from momc and ibtool (all tools that use wrappers.java to combine outputs for bazel).