### PR TITLE
Make source jars from java_library available to Skylark.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaSourceJarsProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaSourceJarsProvider.java
@@ -19,11 +19,14 @@ import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.analysis.TransitiveInfoProvider;
 import com.google.devtools.build.lib.collect.nestedset.NestedSet;
 import com.google.devtools.build.lib.concurrent.ThreadSafety.Immutable;
+import com.google.devtools.build.lib.syntax.SkylarkCallable;
+import com.google.devtools.build.lib.syntax.SkylarkModule;
 
 /**
  * The collection of source jars from the transitive closure.
  */
 @Immutable
+@SkylarkModule(name = "JavaSourceJarsProvider", doc = "")
 public final class JavaSourceJarsProvider implements TransitiveInfoProvider {
 
   private final NestedSet<Artifact> transitiveSourceJars;
@@ -46,6 +49,7 @@ public final class JavaSourceJarsProvider implements TransitiveInfoProvider {
   /**
    * Return the source jars that are to be built when the target is on the command line.
    */
+  @SkylarkCallable(name = "source_jars", doc = "", structField = true)
   public ImmutableList<Artifact> getSourceJars() {
     return sourceJars;
   }


### PR DESCRIPTION
This is necessary to implement GWT support in Bazel, which requires source jars
on the classpath. With this change, I can build a GWT classpath as follows:
```python
  all_deps = ctx.files.deps
  for this_dep in ctx.attr.deps:
    p = provider(this_dep, "rules.java.JavaSourceJarsProvider")
    if p: all_deps += p.source_jars
  classpath = ":".join([dep.path for dep in all_deps])
```

See #146 for discussion