### PR TITLE
Fix tests with python3 as default python.

### DIFF
--- a/examples/py/bin.py
+++ b/examples/py/bin.py
@@ -1,3 +1,3 @@
 from examples.py import lib
 
-print "Fib(5)=%d" % lib.Fib(5)
+print("Fib(5)=%d" % lib.Fib(5))

--- a/src/test/shell/bazel/bazel_example_test.sh
+++ b/src/test/shell/bazel/bazel_example_test.sh
@@ -117,7 +117,7 @@ function test_python() {
   expect_log "Fib(5)=8"
 
   # Mutate //examples/py:bin so that it needs to build again.
-  echo "print 'Hello'" > ./examples/py/bin.py
+  echo "print('Hello')" > ./examples/py/bin.py
   # Ensure that we can rebuild //examples/py::bin without error.
   assert_build "//examples/py:bin"
   ./bazel-bin/examples/py/bin >& $TEST_log \


### PR DESCRIPTION
If the system python interpreter is set to python3, some tests fail
because python3 requires parenthesies for the print statement.
Fix this by adding the required parenthesies, which are a no-op for
python2.