### PR TITLE
New-style android example with dependencies

### DIFF
--- a/examples/android/java/bazel/BUILD
+++ b/examples/android/java/bazel/BUILD
@@ -14,6 +14,7 @@ android_binary(
         ":jni",
         ":lib",
     ],
+    legacy_native_support = 0,
 )
 
 cc_library(

--- a/examples/android/java/bazel/BUILD
+++ b/examples/android/java/bazel/BUILD
@@ -19,4 +19,10 @@ android_binary(
 cc_library(
     name = "jni",
     srcs = ["jni.cc"],
+    deps = [":jni_dep"],
+)
+
+cc_library(
+    name = "jni_dep",
+    srcs = ["jni_dep.cc"],
 )

--- a/examples/android/java/bazel/MainActivity.java
+++ b/examples/android/java/bazel/MainActivity.java
@@ -14,7 +14,7 @@ public class MainActivity extends Activity {
 
     Log.v("Bazel", "Hello, Android");
     Log.v("Bazel", "Lib says: " + Lib.message());
-    System.loadLibrary("jni");
+    System.loadLibrary("hello_world");
     Log.v("Bazel", "JNI says: " + Jni.hello());
   }
 }

--- a/examples/android/java/bazel/jni.cc
+++ b/examples/android/java/bazel/jni.cc
@@ -1,21 +1,8 @@
 #include <jni.h>
-#include <stdlib.h>
-#include <string.h>
+
+#include "examples/android/java/bazel/jni_dep.h"
 
 const char* hello = "Hello JNI";
-
-static jstring NewStringLatin1(JNIEnv *env, const char *str) {
-  int len = strlen(str);
-  jchar *str1;
-  str1 = reinterpret_cast<jchar *>(malloc(len * sizeof(jchar)));
-
-  for (int i = 0; i < len ; i++) {
-    str1[i] = (unsigned char) str[i];
-  }
-  jstring result = env->NewString(str1, len);
-  free(str1);
-  return result;
-}
 
 extern "C" JNIEXPORT jstring JNICALL
 Java_bazel_Jni_hello(JNIEnv *env, jclass clazz) {

--- a/examples/android/java/bazel/jni_dep.cc
+++ b/examples/android/java/bazel/jni_dep.cc
@@ -1,0 +1,18 @@
+#include "examples/android/java/bazel/jni_dep.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+jstring NewStringLatin1(JNIEnv *env, const char *str) {
+  int len = strlen(str);
+  jchar *str1;
+  str1 = reinterpret_cast<jchar *>(malloc(len * sizeof(jchar)));
+
+  for (int i = 0; i < len ; i++) {
+    str1[i] = (unsigned char) str[i];
+  }
+  jstring result = env->NewString(str1, len);
+  free(str1);
+  return result;
+}
+

--- a/examples/android/java/bazel/jni_dep.h
+++ b/examples/android/java/bazel/jni_dep.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include <jni.h>
+
+jstring NewStringLatin1(JNIEnv *env, const char *str);


### PR DESCRIPTION
These were the changes needed to get the android example building without legacy native support, plus the initial change (making the jni lib depend on another cc_library) that motivated it.